### PR TITLE
Use native double quotes interpretation of n:src parameter.

### DIFF
--- a/TimestampMacro.php
+++ b/TimestampMacro.php
@@ -27,7 +27,7 @@ class TimestampMacro extends Latte\Macros\MacroSet
 		}
 
 		$class = get_called_class();
-		return $writer->write(' ?> ' . $node->name . '="<?php echo %escape(' . $class . '::getFileTimestamp(\'' . $node->args . '\', $_presenter->context->parameters[\'wwwDir\'])) ?>"<?php ');
+		return $writer->write(' ?> ' . $node->name . '="<?php echo %escape(' . $class . '::getFileTimestamp("' . $node->args . '", $_presenter->context->parameters[\'wwwDir\'])) ?>"<?php ');
 	}
 
 


### PR DESCRIPTION
Now is possible to use something like this `n:src="banner.{$locale}.png"`. 

But its is BC break, because it is different interpretation of generated PHP code.
